### PR TITLE
Fix chart collapsing to a hairline after switching back to 7d

### DIFF
--- a/src/components/ResultChart.tsx
+++ b/src/components/ResultChart.tsx
@@ -53,19 +53,30 @@ const useEasedPair = (target: [number, number], instant: boolean): [number, numb
     const [shown, setShown] = useState<[number, number]>(target);
     const shownRef = useRef<[number, number]>(target);
     const targetRef = useRef<[number, number]>(target);
+    const rafRef = useRef(0);
+    const lastRef = useRef(0);
     targetRef.current = target;
 
+    // The loop lives across renders rather than inside one. It reads the target
+    // through a ref, so a target that keeps moving (the window tracks "now", and
+    // the y domain follows the slice the ease itself is widening) just steers the
+    // animation already in flight. Tearing the effect down and rebuilding it on
+    // every target change instead cancelled the pending frame before it could
+    // run, and the ease then never advanced at all: switching 30d/all back to 7d
+    // left the drawn window stuck on the old one, squeezing the whole visible
+    // range into a hairline at the right-hand edge.
     useEffect(() => {
         if (instant || prefersReducedMotion()) {
-            shownRef.current = target;
-            setShown(target);
+            if (rafRef.current) { cancelAnimationFrame(rafRef.current); rafRef.current = 0; }
+            shownRef.current = targetRef.current;
+            setShown(targetRef.current);
             return;
         }
-        let raf = 0;
-        let last = performance.now();
+        if (rafRef.current) return;                     // already easing — let it keep going
+        lastRef.current = performance.now();
         const step = (now: number) => {
-            const dt = Math.min(64, now - last);
-            last = now;
+            const dt = Math.min(64, now - lastRef.current);
+            lastRef.current = now;
             const [tl, th] = targetRef.current;
             const [cl, ch] = shownRef.current;
             const k = 1 - Math.exp(-dt / 95);            // ~95 ms time constant
@@ -75,12 +86,13 @@ const useEasedPair = (target: [number, number], instant: boolean): [number, numb
             const done = Math.abs(nl - tl) / span < 1e-4 && Math.abs(nh - th) / span < 1e-4;
             shownRef.current = done ? [tl, th] : [nl, nh];
             setShown(shownRef.current);
-            if (!done) raf = requestAnimationFrame(step);
+            rafRef.current = done ? 0 : requestAnimationFrame(step);
         };
-        raf = requestAnimationFrame(step);
-        return () => cancelAnimationFrame(raf);
+        rafRef.current = requestAnimationFrame(step);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [target[0], target[1], instant]);
+
+    useEffect(() => () => { if (rafRef.current) cancelAnimationFrame(rafRef.current); }, []);
 
     return shown;
 };
@@ -223,7 +235,18 @@ const ResultChart = ({
         });
     }, [sim, calibrationFn, isTransmasc, primaryIsCPA, hasSecondary]);
 
-    const now = Date.now();
+    // A clock that ticks, not one that is read on every render. `now` anchors the
+    // visible window, the "now" marker and the calibration read-off; taking it
+    // from Date.now() inline made every one of those a fresh value on each of the
+    // ~60 renders a second an animation produces, so nothing downstream of it
+    // could ever settle. A minute is finer than this chart resolves, and it is
+    // the cadence the readings above it already refresh on.
+    const [now, setNow] = useState(() => Date.now());
+    useEffect(() => {
+        const id = setInterval(() => setNow(Date.now()), 60000);
+        return () => clearInterval(id);
+    }, []);
+
     const fullMin = data.length ? data[0].t : now;
     const fullMax = data.length ? data[data.length - 1].t : now;
 


### PR DESCRIPTION
Switching the range from 全部/30天 back to 7天 left the plot drawn on the
old, much wider window: the whole 7-day range — curve, dose markers, the
"now" line — was squeezed into ~1% of the plot at the right-hand edge, the
four x labels stacked on top of each other into one unreadable date, and
the y axis kept the full-history maximum (1500 pg/ml against a 7-day peak
of 265). It never recovered; the chart stayed like that indefinitely.

Two causes, both in ResultChart:

`now` was read from Date.now() during render, so baseWindow, t0/t1 and
everything memoised off them were a new value on every render. That made
useEasedPair's effect dependencies change on every render too, and its
cleanup then cancelled the pending animation frame before it could run.
The ease could not advance a single step, so the drawn window never moved
off the one it was leaving. It also kept the component re-rendering at
~60 fps forever (measured: 118 DOM mutations per 2s sitting idle), each
render rebuilding a monotone-cubic path over the whole simulation grid,
because `slice` spans the union of the target and drawn windows.

`now` now ticks on a 60s interval — the cadence the readings above the
chart already use, and finer than the chart resolves — and useEasedPair
keeps one animation loop alive across renders, steering it through the
target ref instead of tearing it down and rebuilding it whenever the
target moves. The loop stops itself once it converges.

Verified against the reporter's own records (173 doses, ~19 months) in
Chromium: 全部→7天, 30天→7天, 7天→30天 and 全部→30天 all settle on the
correct window (7d: 0-300 pg/ml, four distinct labels 8月20日-8月27日,
"now" at 50%), and idle DOM mutations drop from 118 per 2s to 0.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Rt2AD9iEPsvPrXRWAB33Dp