### PR TITLE
Index content(user_id, created_at) to stop full-table scans

### DIFF
--- a/docker/schema.sql
+++ b/docker/schema.sql
@@ -13,7 +13,10 @@ CREATE TABLE IF NOT EXISTS content (
     created_at INTEGER DEFAULT (unixepoch()),
     FOREIGN KEY (user_id) REFERENCES users(id)
 );
-CREATE INDEX IF NOT EXISTS idx_content_user_id ON content(user_id);
+-- Composite so `WHERE user_id = ? ORDER BY created_at DESC` is served entirely
+-- from the index, with no temp B-tree sort. See migrations/0003.
+CREATE INDEX IF NOT EXISTS idx_content_user_created ON content(user_id, created_at);
+DROP INDEX IF EXISTS idx_content_user_id;
 
 CREATE TABLE IF NOT EXISTS sessions (
     id TEXT PRIMARY KEY,

--- a/migrations/0003_add_content_user_index.sql
+++ b/migrations/0003_add_content_user_index.sql
@@ -1,0 +1,17 @@
+-- The hot path. `content` was the only table whose indexes were never created
+-- in production: every other table gets its indexes from an ensure*() call in
+-- worker.ts, while content relied on schema.sql — which opens with DROP TABLE
+-- and so is only ever run against a fresh local database.
+--
+-- Without this, `WHERE user_id = ? ORDER BY created_at DESC` was a full SCAN of
+-- the whole table plus a temp B-tree sort: ~10,300 rows read to return the ~10
+-- backups belonging to one user, on every backup-list and every backup-save.
+-- Those two queries alone accounted for over 99% of the database's rows read.
+--
+-- The pair (user_id, created_at) satisfies the filter and the ordering together,
+-- so the sort disappears as well; SQLite walks the index backwards for DESC.
+CREATE INDEX IF NOT EXISTS idx_content_user_created ON content(user_id, created_at);
+
+-- Superseded by the composite above, whose leftmost column is user_id.
+-- Dropped where it exists so writes don't maintain two indexes for one lookup.
+DROP INDEX IF EXISTS idx_content_user_id;

--- a/schema.sql
+++ b/schema.sql
@@ -16,7 +16,9 @@ CREATE TABLE content (
     created_at INTEGER DEFAULT (unixepoch()),
     FOREIGN KEY (user_id) REFERENCES users(id)
 );
-CREATE INDEX idx_content_user_id ON content(user_id);
+-- Composite so `WHERE user_id = ? ORDER BY created_at DESC` is served entirely
+-- from the index, with no temp B-tree sort. See migrations/0003.
+CREATE INDEX idx_content_user_created ON content(user_id, created_at);
 
 DROP TABLE IF EXISTS sessions;
 CREATE TABLE sessions (

--- a/worker.ts
+++ b/worker.ts
@@ -377,6 +377,27 @@ async function consumeTOTP(env: Env, userId: string, secret: string, token: stri
   return true;
 }
 
+// --- Content indexes lazy creation ---
+// `content` predates the ensure*() pattern every other table uses, so its index
+// only ever existed in schema.sql — a file that opens with DROP TABLE and is
+// therefore never run against a database that holds real data. The result was a
+// full table scan plus a temp B-tree sort on every per-user backup query. See
+// migrations/0003_add_content_user_index.sql; this mirror keeps a self-hosted
+// database that skips the numbered migrations from silently paying the same
+// cost, and is a no-op once the index is there.
+let contentIndexesEnsured = false;
+async function ensureContentIndexes(env: Env): Promise<void> {
+  if (contentIndexesEnsured) return;
+  try {
+    await env.DB.prepare('CREATE INDEX IF NOT EXISTS idx_content_user_created ON content(user_id, created_at)').run();
+    // Superseded by the composite above, whose leftmost column is user_id.
+    await env.DB.prepare('DROP INDEX IF EXISTS idx_content_user_id').run();
+    contentIndexesEnsured = true;
+  } catch (e) {
+    console.error('Failed to ensure content indexes:', e);
+  }
+}
+
 // --- Sessions table lazy creation ---
 // Revoke sessions left idle beyond this window (seconds). Shorter than the
 // 7-day JWT lifetime so inactivity caps how long a stolen token survives.
@@ -547,20 +568,30 @@ async function ensureDosageShares(env: Env): Promise<void> {
     // Local/self-hosted databases may have been created before live sharing
     // existed and might not have run the numbered D1 migration. Inspect first
     // and tolerate a concurrent Worker isolate winning the ALTER race.
-    const ensureColumn = async (name: string, ddl: string): Promise<void> => {
+    // Reports whether *this* call added the column, so the one-time backfill
+    // below runs only alongside the ALTER that makes it necessary.
+    const ensureColumn = async (name: string, ddl: string): Promise<boolean> => {
       const columns = await env.DB.prepare('PRAGMA table_info(dosage_shares)').all<{ name: string }>();
-      if ((columns.results || []).some(column => column.name === name)) return;
+      if ((columns.results || []).some(column => column.name === name)) return false;
       try {
         await env.DB.prepare(ddl).run();
+        return true;
       } catch (error) {
         const refreshed = await env.DB.prepare('PRAGMA table_info(dosage_shares)').all<{ name: string }>();
         if (!(refreshed.results || []).some(column => column.name === name)) throw error;
+        return false;
       }
     };
     await ensureColumn('is_live', 'ALTER TABLE dosage_shares ADD COLUMN is_live INTEGER NOT NULL DEFAULT 0');
     await ensureColumn('share_mode', 'ALTER TABLE dosage_shares ADD COLUMN share_mode TEXT');
-    await ensureColumn('updated_at', 'ALTER TABLE dosage_shares ADD COLUMN updated_at INTEGER');
-    await env.DB.prepare('UPDATE dosage_shares SET updated_at = created_at WHERE updated_at IS NULL').run();
+    const addedUpdatedAt = await ensureColumn('updated_at', 'ALTER TABLE dosage_shares ADD COLUMN updated_at INTEGER');
+    // Backfill for the ALTER directly above, and only for it. Unconditionally it
+    // scanned the whole table on every cold isolate to update nothing — roughly
+    // 11,700 pointless scans a week. Rows that predate the column are already
+    // covered by migrations/0002, and every read site falls back to created_at.
+    if (addedUpdatedAt) {
+      await env.DB.prepare('UPDATE dosage_shares SET updated_at = created_at WHERE updated_at IS NULL').run();
+    }
 
     await env.DB.prepare('CREATE INDEX IF NOT EXISTS idx_dosage_shares_user_id ON dosage_shares(user_id)').run();
     await env.DB.prepare('CREATE UNIQUE INDEX IF NOT EXISTS idx_dosage_shares_token_hash ON dosage_shares(token_hash)').run();
@@ -1555,6 +1586,7 @@ export default {
 
         // Content
         if (url.pathname.startsWith('/api/content')) {
+          await ensureContentIndexes(env);
           if (url.pathname === '/api/content' && request.method === 'GET') {
             const metaOnly = url.searchParams.get('meta') === '1';
             if (metaOnly) {


### PR DESCRIPTION
## What

`content` was the only table whose indexes never existed in production. Every other table creates its own via an `ensure*()` call in `worker.ts`; `content` relied on `schema.sql`, which opens with `DROP TABLE` and so is only ever run against a fresh local database. Production had nothing on it but the primary key autoindex.

This adds a composite index on `content(user_id, created_at)`, mirrors it in a lazy `ensureContentIndexes()` for databases that skip the numbered migrations, and fixes a second scan that fired on every cold isolate.

## Why

Every per-user backup query planned as `SCAN content` plus a temp B-tree sort: about 10,300 rows read to return the ~10 backups belonging to one user.

`wrangler d1 insights`, 7 days:

| Query | Rows read | Runs | Rows/run |
|---|---:|---:|---:|
| `SELECT id, created_at, LENGTH(data) … WHERE user_id = ?` | 169,065,323 | 16,399 | 10,309 |
| `SELECT id … WHERE user_id = ? ORDER BY created_at DESC LIMIT -1 OFFSET ?` | 36,592,990 | 3,549 | 10,310 |
| `UPDATE dosage_shares SET updated_at = created_at WHERE updated_at IS NULL` | 386,879 | 11,700 | 33 |

The two `content` queries are 205.7M of ~206M total rows read, roughly 99.6% of the database's entire read volume, against a 5M/day plan limit. The dashboard was reading 429.63M against that 5M.

## Changes

- **`migrations/0003_add_content_user_index.sql`** — composite index on `(user_id, created_at)`. Composite rather than `user_id` alone so the filter and the ordering are served together and the sort disappears as well; SQLite walks the index backwards for `DESC`. Drops the now-redundant `idx_content_user_id` where it exists so writes don't maintain two indexes for one lookup.
- **`worker.ts`** — `ensureContentIndexes()`, matching the lazy pattern the other tables already use, called on the `/api/content` routes. A no-op once the index is there. This is what stops the same gap from silently reappearing on a self-hosted deployment.
- **`worker.ts`** — `ensureColumn()` in `ensureDosageShares()` now reports whether *it* added the column, and the `updated_at` backfill is gated on that. It previously ran unconditionally on every cold isolate: ~11,700 whole-table scans a week to update nothing. Rows predating the column are already covered by migration `0002`, and every read site already falls back to `created_at` (`share.updated_at ?? share.created_at`).
- **`schema.sql`, `docker/schema.sql`** — kept in sync for fresh installs.

## Verification

All three content queries, checked against production after applying the migration:

```
SEARCH content USING INDEX idx_content_user_created (user_id=?)
```

`USE TEMP B-TREE FOR ORDER BY` is gone from all three. Measured on a real user's backup list: **3 rows read, down from 10,309**.

`npx tsc --noEmit` clean, `wrangler deploy --dry-run` bundles clean.

## Reviewer notes

- **Migration 0003 is already applied to `hrt-tracker-prod`.** The index is a database object, so the fix is live against the currently deployed worker and does not wait on this PR merging. Merging and deploying picks up the worker-side changes.
- Deliberately left alone: `SELECT COUNT(*) FROM content` on the admin dashboard still scans, but at 35 runs/week it is 0.17% of the total and fixing it properly needs a counter table. An index on `users(created_at)` would save another 160k reads/week (0.08%), not worth the write-quota cost right now.
- One discrepancy worth naming: the D1 dashboard reported 429.63M while insights recorded 206M over 7 days, so insights is likely sampled or capped to top queries. The proportion is what the fix turns on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
