### PR TITLE
用药记录跨年显示异常: group by the day, not by a heading that omits the year

### DIFF
--- a/src/hooks/useAppData.ts
+++ b/src/hooks/useAppData.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { DoseEvent, Route, Ester, SimulationResult, runSimulation, interpolateConcentration_E2, interpolateConcentration_CPA, interpolateConcentration_T, LabResult, computeCalibration, CalibrationMethod, CalibrationHistoryMode, normalizeCalibrationMethod, isTestosteroneEster, isT_LabUnit, PKCustomParams, applyPKOverrides, sanitizePKParams, isPlausibleBodyWeightKG,
          BODY_WEIGHT_KG_MIN, BODY_WEIGHT_KG_MAX, DOSE_MG_MAX,
          EVENT_TIME_H_MIN, EVENT_TIME_H_MAX } from '../../logic';
-import { formatDate } from '../utils/helpers';
+import { createDayLabelFormatter, toDayKey } from '../utils/helpers';
 import { useTranslation } from '../contexts/LanguageContext';
 import { useHRTMode } from '../contexts/HRTModeContext';
 import { useAuth } from '../contexts/AuthContext';
@@ -82,6 +82,15 @@ export interface QuickDose {
     ester: Ester;
     value: number;
     createdAt: number;
+}
+
+/** One day's worth of dose records, as the history list renders them. */
+export interface DoseDayGroup {
+    /** Stable "YYYY-MM-DD" identity. For grouping and React keys, never for display. */
+    key: string;
+    /** What the section heading shows, in the reader's language. */
+    label: string;
+    events: DoseEvent[];
 }
 
 export const useAppData = (showDialog: (type: 'alert' | 'confirm', message: string, onConfirm?: () => void) => void) => {
@@ -352,14 +361,28 @@ export const useAppData = (showDialog: (type: 'alert' | 'confirm', message: stri
         return interpolateConcentration_T(simulation, h) || 0;
     }, [simulation, currentTime]);
 
-    const groupedEvents = useMemo(() => {
+    // One section per local calendar day, newest first.
+    //
+    // #69: this used to accumulate into an object keyed by the day's *display*
+    // label, which carries no year, so a dose on 2025-08-27 and one on 2026-08-27
+    // hashed to the same bucket and rendered under a single "8月27日" heading.
+    // Key and heading are two separate values now.
+    //
+    // An array rather than a Record, because `sorted` is already newest-first and
+    // run-length grouping keeps that order structurally. Object key enumeration
+    // would not: it quietly re-sorts any key that looks like an array index, so a
+    // key such as "20260827" would have come back oldest-first.
+    const groupedEvents = useMemo<DoseDayGroup[]>(() => {
+        const formatLabel = createDayLabelFormatter(lang);
         const sorted = [...events].sort((a, b) => b.timeH - a.timeH);
-        const groups: Record<string, DoseEvent[]> = {};
-        sorted.forEach(e => {
-            const d = formatDate(new Date(e.timeH * 3600000), lang);
-            if (!groups[d]) groups[d] = [];
-            groups[d].push(e);
-        });
+        const groups: DoseDayGroup[] = [];
+        for (const e of sorted) {
+            const at = new Date(e.timeH * 3600000);
+            const key = toDayKey(at);
+            const last = groups[groups.length - 1];
+            if (last && last.key === key) last.events.push(e);
+            else groups.push({ key, label: formatLabel(at), events: [e] });
+        }
         return groups;
     }, [events, lang]);
 

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -7,6 +7,7 @@ import { useDialog } from '../contexts/DialogContext';
 import DoseForm from '../components/DoseForm';
 import PixelCat from '../components/PixelCat';
 import { DoseTemplate } from '../components/DoseFormModal';
+import { DoseDayGroup } from '../hooks/useAppData';
 
 // Trim trailing zeros so wear durations read "3.5" / "7" rather than "3.50".
 const formatWearDays = (days: number): string =>
@@ -30,7 +31,7 @@ interface HistoryProps {
     onDeleteEvents: (ids: string[]) => void;
     onSaveTemplate: (t: DoseTemplate) => void;
     onDeleteTemplate: (id: string) => void;
-    groupedEvents: Record<string, DoseEvent[]>;
+    groupedEvents: DoseDayGroup[];
 }
 
 const History: React.FC<HistoryProps> = ({
@@ -58,7 +59,7 @@ const History: React.FC<HistoryProps> = ({
     const [selectMode, setSelectMode] = useState(false);
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
-    const allEvents = Object.values(groupedEvents).flat() as DoseEvent[];
+    const allEvents = groupedEvents.flatMap(g => g.events);
     const totalRecords = allEvents.length;
     const nowH = Date.now() / 3600000;
 
@@ -234,22 +235,22 @@ const History: React.FC<HistoryProps> = ({
                 </div>
             </div>
 
-            {Object.keys(groupedEvents).length === 0 && (
+            {groupedEvents.length === 0 && (
                 <div className="px-6 md:px-8 flex flex-col items-center text-center py-20 max-w-2xl text-[var(--color-m3-on-surface-variant)] dark:text-[var(--color-m3-dark-on-surface-variant)]">
                     <PixelCat pose="donut" className="mb-4" />
                     <p className="text-sm">{t('timeline.empty')}</p>
                 </div>
             )}
 
-            {Object.keys(groupedEvents).length > 0 && (
+            {groupedEvents.length > 0 && (
             <div className="px-6 md:px-8 max-w-2xl">
-                {Object.entries(groupedEvents).map(([date, items]) => (
-                    <div key={date} className="mb-6 last:mb-0">
+                {groupedEvents.map(({ key, label, events: dayEvents }) => (
+                    <div key={key} className="mb-6 last:mb-0">
                         <div className="sticky top-[94px] z-10 bg-[var(--color-m3-surface-dim)] dark:bg-[var(--color-m3-dark-surface)] py-2">
-              <span className="text-xs font-semibold text-[var(--color-m3-on-surface-variant)] dark:text-[var(--color-m3-dark-on-surface-variant)]">{date}</span>
+              <span className="text-xs font-semibold text-[var(--color-m3-on-surface-variant)] dark:text-[var(--color-m3-dark-on-surface-variant)]">{label}</span>
                         </div>
                         <div>
-                            {(items as DoseEvent[]).map(ev => {
+                            {dayEvents.map(ev => {
                                 const isEditing = editingId === ev.id;
                                 const isSelected = selectedIds.has(ev.id);
                                 const isFuture = ev.timeH > nowH;

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -17,6 +17,45 @@ export const formatDate = (date: Date, lang: Lang, timeZone?: string) => {
 };
 
 /**
+ * `formatDate` plus the year, for a date that has to stand on its own instead of
+ * borrowing context from its neighbours: a list section heading, a table cell.
+ * `formatDate` stays year-less because it also labels the chart's x-axis, where
+ * the surrounding ticks imply the year and twice-as-wide labels would overlap.
+ *
+ * A factory because `toLocaleDateString` rebuilds an ICU formatter every call:
+ * over a few thousand events, ~900ms against ~20ms for one reused formatter.
+ *
+ * The NaN check is what keeps this total. `toLocaleDateString` returns "Invalid
+ * Date" for an unrepresentable date; `Intl.DateTimeFormat` throws instead, and
+ * the caller runs inside a `useMemo` in the render body, so an unguarded throw
+ * is not one spoiled heading but the whole app replaced by the error boundary.
+ * Such a record needs no devtools: batch add multiplies an unbounded interval
+ * into `timeH`. Returning the old string leaves that case rendering as it did.
+ */
+export const createDayLabelFormatter = (lang: Lang) => {
+    const fmt = new Intl.DateTimeFormat(LOCALE_MAP[lang] || 'en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+    return (date: Date): string => Number.isNaN(date.getTime()) ? 'Invalid Date' : fmt.format(date);
+};
+
+/**
+ * Which local calendar day a moment falls on, as "YYYY-MM-DD": the identity
+ * behind a heading, never the heading itself.
+ *
+ * The dose history used to group by the rendered label, which carries no year,
+ * so a dose on 2025-08-27 and one on 2026-08-27 collapsed under a single
+ * "8月27日" (#69). With the key split off, shortening the heading can no longer
+ * merge records, and switching language no longer re-partitions the list.
+ *
+ * Local fields rather than `toISOString()`, which reports the UTC day and would
+ * file a 01:00 dose under the day before anywhere east of Greenwich. This and
+ * the label above must keep agreeing on the day, so neither takes a `timeZone`.
+ * An unrepresentable date yields one stable key instead of throwing, collecting
+ * those records into a single section as the old "Invalid Date" bucket did.
+ */
+export const toDayKey = (date: Date): string =>
+    `${String(date.getFullYear()).padStart(4, '0')}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+
+/**
  * "3h ago", in the reader's language.
  *
  * Three pages grew their own copy of this and two of them hardcoded English,


### PR DESCRIPTION
Fixes #69

## The bug

In 用药记录, a record from a previous year merged into the current year's section for the same month and day. Creating a dose on 2025-08-27 and one on 2026-08-27 put both under a single `8月27日` heading.

The 概览 chart was never affected, which is why the curves looked right: it plots `timeH` directly and never touches the grouping map.

## Root cause

`groupedEvents` in `src/hooks/useAppData.ts` accumulated events into an object keyed by the day's **display label**:

```ts
const d = formatDate(new Date(e.timeH * 3600000), lang);
if (!groups[d]) groups[d] = [];
groups[d].push(e);
```

`formatDate` formats `{ month: 'short', day: 'numeric' }`, with no year. Two dates a year apart produce the same string, so they hashed to the same bucket. The defect is the class, not the instance: a localized string meant for display was doing duty as a data key.

## The fix

Key and heading are two separate values now.

- **`toDayKey`** returns a locale-independent `"YYYY-MM-DD"` identity. Built from local calendar fields rather than `toISOString()`, which reports the UTC day and would file a 01:00 dose under the previous date anywhere east of Greenwich.
- **`createDayLabelFormatter`** renders the heading with the year. Kept separate from `formatDate`, which stays year-less on purpose because it also labels the chart's x-axis ticks, where neighbouring ticks already imply the year and doubling every label's width would overlap them. It is a factory because `toLocaleDateString` rebuilds an ICU formatter on every call: roughly 900ms against 20ms over a few thousand events.
- **`groupedEvents` became `DoseDayGroup[]`** instead of `Record<string, DoseEvent[]>`. Run-length grouping over the already-sorted list keeps newest-first ordering structurally, instead of leaning on object key enumeration, which quietly re-sorts any key resembling an array index (a key like `"20260827"` would have come back oldest-first).

`src/App.tsx` needs no change, since the label is built in the hook rather than in the page.

## One thing worth a reviewer's attention

`Intl.DateTimeFormat#format` **throws** `RangeError` on an unrepresentable date, where `toLocaleDateString` returns the string `"Invalid Date"`. This code runs inside a `useMemo` in the app's render body, so swapping a total function for a partial one would mean the whole app drops to the error boundary rather than one heading rendering oddly.

That is reachable without devtools: batch add multiplies an unvalidated interval into `timeH` (`History.tsx`), and neither `addEvents` nor the inert `min` attribute enforces `EVENT_TIME_H_MAX`. So `createDayLabelFormatter` guards on `NaN` and returns the same string the old code did, leaving such a record rendering exactly as it does today. Verified in the browser: it lands in its own `Invalid Date` section and stays deletable.

## Verification

No test framework in this repo, so this was checked by hand.

- `tsc --noEmit` clean, `npm run build` clean.
- Dev server, seeded with the issue's repro plus a second dose on the 2026 day and one on the day before:

| heading | rows |
| --- | --- |
| 2026年8月27日 | 21:00, 09:00 |
| 2026年8月26日 | 09:00 |
| 2025年8月27日 | 09:00 |

  Same-day records still merge, a year apart no longer do, order stays descending.
- Confirmed in English too (`Aug 27, 2026` / `Aug 27, 2025`). All 7 locales render a distinct, unambiguous string per calendar day.
- Unrepresentable timestamp: no crash, own section, still deletable.
- Empty state still renders.

## Follow-ups, deliberately not in this PR

1. `src/services/export.ts:32,45,87,107` carry the same year-less format, and there it loses data: neither the CSV nor the PDF writes a raw timestamp, so the year is unrecoverable from the file, and spreadsheets parse a bare `Aug 27` as the current year. `createDayLabelFormatter` is a drop-in at all four sites.
2. Batch add writes unvalidated timestamps. `EVENT_TIME_H_MIN`/`MAX` are enforced only in `sanitizeImportedEvents`, so quick-add can create records that import and cloud sync then silently drop.
3. Cosmetic: `ResultChart.tsx:452` dedupes x-axis ticks by label, so an "All" range spanning about a year can silently drop a tick. No data loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
