### PR TITLE
Spin an arc while syncing, not two arrowheads that smear into a blob

### DIFF
--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { UploadCloud, LogOut, BadgeCheck, Edit2, Loader2, Trash2, Cloud, HardDrive, DownloadCloud, Merge, ChevronDown, Plus, Minus, Fingerprint, Lock, MonitorSmartphone, RefreshCw, CloudOff, CheckCircle2, AlertCircle } from 'lucide-react';
+import { UploadCloud, LogOut, BadgeCheck, Edit2, Loader2, Trash2, Cloud, HardDrive, DownloadCloud, Merge, ChevronDown, Plus, Minus, Fingerprint, Lock, MonitorSmartphone, CloudOff, CheckCircle2, AlertCircle } from 'lucide-react';
 import ShieldIcon from '../components/ShieldIcon';
 import { SettingsListItem } from '../components/SettingsListItem';
 
@@ -54,7 +54,7 @@ type UnlockTarget =
 
 const SyncIcon: React.FC<{ status: SyncStatus; className?: string }> = ({ status, className }) => {
     switch (status) {
-        case 'syncing': return <RefreshCw size={18} className={`${className} animate-spin`} />;
+        case 'syncing': return <Loader2 size={18} className={`${className} animate-spin`} />;
         case 'synced': return <CheckCircle2 size={18} className={className} />;
         case 'locked': return <Lock size={18} className={className} />;
         case 'error': return <AlertCircle size={18} className="text-amber-600 dark:text-amber-400 shrink-0" />;


### PR DESCRIPTION
The sync status row in Account settings used `RefreshCw` under `animate-spin`. That glyph is two curved arrows closed into a ring, each ending in a flat triangular head, and at `size={18}` with lucide's default stroke of 2 the heads sit almost on top of the tails they point at. Rotating it at 1s linear smears the dense middle, so it reads as a knot rather than as something in progress.

## What changed

One branch of `SyncIcon` in `src/pages/Account.tsx`:

```diff
-case 'syncing': return <RefreshCw size={18} className={`${className} animate-spin`} />;
+case 'syncing': return <Loader2 size={18} className={`${className} animate-spin`} />;
```

`Loader2` is the open arc lucide ships for this. It has no arrowheads, so nothing about it changes shape as it turns.

## Why this one

`Loader2` was already imported in the file, because it is what every other in-progress state on the page uses. That includes the "Backup to Cloud" row directly beneath this one, so during a save the two adjacent rows were spinning two different shapes at the same speed. They match now.

## Notes for review

- Only the `'syncing'` branch animates and only it had the problem, so the other four (`synced`, `locked`, `error`, `off`) are untouched.
- `RefreshCw` leaves this file's import list. It stays in `ErrorBoundary` and `TwoFactor`, where it labels a button the user presses and never rotates, so those are unaffected.
- No string, state, or behavior change. `tsc --noEmit` is clean.

Verified by rendering the two paths from the installed lucide 0.344 at the real size, stroke, and surface colors, in both light and dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)